### PR TITLE
Update studiocms URL

### DIFF
--- a/apps/site/src/content/projects/studiocms.mdx
+++ b/apps/site/src/content/projects/studiocms.mdx
@@ -2,7 +2,7 @@
 name: astrolicious/studiocms
 kind: misc
 links:
-    website: https://astro-studiocms.xyz
+    website: https://studiocms.xyz
     github: https://github.com/astrolicious/studiocms
 ---
 


### PR DESCRIPTION
We recently changed StudioCMS's domain name to be simply `studiocms.xyz` instead of `astro-studiocms.xyz`